### PR TITLE
remove remotes in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,10 +24,7 @@ Imports:
     swirl,
     tm,
     wordcloud
-Remotes:
-  hadley/pkgdown,
-  yihui/printr
 License: GPL-2
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.0
+RoxygenNote: 6.0.1


### PR DESCRIPTION
The remotes referred to packages only used for building the data and package website, and thus should not be included in the DESCRIPTION.